### PR TITLE
fix props not passed down to rendered component

### DIFF
--- a/imports/ui/components/Authenticated/Authenticated.js
+++ b/imports/ui/components/Authenticated/Authenticated.js
@@ -7,8 +7,8 @@ const Authenticated = ({ loggingIn, authenticated, component, ...rest }) => (
     {...rest}
     render={props => (
       authenticated ?
-      (React.createElement(component, { ...props, loggingIn, authenticated })) :
-      (<Redirect to="/logout" />)
+        (React.createElement(component, { ...props, ...rest, loggingIn, authenticated })) :
+        (<Redirect to="/logout" />)
     )}
   />
 );

--- a/imports/ui/components/Public/Public.js
+++ b/imports/ui/components/Public/Public.js
@@ -7,8 +7,8 @@ const Public = ({ loggingIn, authenticated, component, ...rest }) => (
     {...rest}
     render={props => (
       !authenticated ?
-      (React.createElement(component, { ...props, loggingIn, authenticated })) :
-      (<Redirect to="/documents" />)
+        (React.createElement(component, { ...props, ...rest, loggingIn, authenticated })) :
+        (<Redirect to="/documents" />)
     )}
   />
 );


### PR DESCRIPTION
props are now passed down to the component. The props passed down before where the props that <Route /> generates and the parent props where on the rest variable.

I don't think the `<Route />`  component needs all those props, maybe we can leave it with only `path` and the `exact` props.

This fixes issue #32.