### PR TITLE
Fix linter warnings on Windows because of the linebreak-style rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
This fixes issue#59. Description of the problem is there