### PR TITLE
Update dependencies. `babel-preset-es2015` deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
     "enzyme": "^2.9.1",
     "eslint": "^4.6.0",
@@ -40,6 +40,9 @@
     "eslint-plugin-meteor": "^4.1.4",
     "eslint-plugin-react": "^7.3.0",
     "jest": "^20.0.4"
+  },
+  "babel": {
+    "presets": ["env", "react"]
   },
   "eslintConfig": {
     "parserOptions": {


### PR DESCRIPTION
Looks like it works, fixes issue #60