### PR TITLE
Remove unnecessary Babel presets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,4 @@
 {
-  "presets": [
-    "env",
-    "react"
-  ],
   "plugins": [
     "lodash"
   ]

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
   "devDependencies": {
     "babel-jest": "^21.2.0",
     "babel-plugin-lodash": "^3.2.11",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "^6.24.1",
     "enzyme": "^3.1.0",
     "eslint": "^4.10.0",
     "eslint-config-airbnb": "^16.1.0",


### PR DESCRIPTION
As noted by Ben in https://github.com/meteor/meteor/issues/9571#issuecomment-360223847 & https://github.com/meteor/meteor/issues/9469#issuecomment-351552571 these presets are unnecessary because Meteor already provides them. They add unnecessary additional build time and the recommended approach is to use plugins only.  The requests aligns pup with Ben's recommended approach. 