### PR TITLE
Refactor Welcome Email & Settings file

### DIFF
--- a/imports/api/Users/server/methods.js
+++ b/imports/api/Users/server/methods.js
@@ -4,7 +4,7 @@ import { Accounts } from 'meteor/accounts-base';
 import editProfile from './edit-profile';
 import exportData from './export-data';
 import deleteAccount from './delete-account';
-import sendWelcomeEmail from './/send-welcome-email';
+import sendWelcomeEmail from './send-welcome-email';
 import handleMethodException from '../../../modules/handle-method-exception';
 import rateLimit from '../../../modules/rate-limit';
 

--- a/imports/api/Users/server/methods.js
+++ b/imports/api/Users/server/methods.js
@@ -4,6 +4,7 @@ import { Accounts } from 'meteor/accounts-base';
 import editProfile from './edit-profile';
 import exportData from './export-data';
 import deleteAccount from './delete-account';
+import sendWelcomeEmail from './/send-welcome-email';
 import handleMethodException from '../../../modules/handle-method-exception';
 import rateLimit from '../../../modules/rate-limit';
 
@@ -42,6 +43,13 @@ Meteor.methods({
         handleMethodException(exception);
       });
   },
+  'users.sendWelcomeEmail': function userSendWelcomeEmail() {
+    return sendWelcomeEmail()
+      .then(response => response)
+      .catch((exception) => {
+        handleMethodException(exception);
+      });
+  },
 });
 
 rateLimit({
@@ -50,6 +58,7 @@ rateLimit({
     'users.editProfile',
     'users.exportData',
     'users.deleteAccount',
+    'users.sendWelcomeEmail',
   ],
   limit: 5,
   timeRange: 1000,

--- a/imports/api/Users/server/send-welcome-email.js
+++ b/imports/api/Users/server/send-welcome-email.js
@@ -1,14 +1,15 @@
 import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
 import sendEmail from '../../../modules/server/send-email';
 import getOAuthProfile from '../../../modules/get-oauth-profile';
 
-export default (user) => {
-  const tmpUser = !user ? Meteor.user() : user;
-  const OAuthProfile = getOAuthProfile(tmpUser.profile, tmpUser);
+export default (oauthUser) => {
+  const user = !oauthUser ? Meteor.user() : check(oauthUser, Object);
+  const OAuthProfile = getOAuthProfile(user.profile, user);
 
   const applicationName = 'Application Name';
-  const firstName = OAuthProfile ? OAuthProfile.name.first : tmpUser.profile.name.first;
-  const emailAddress = OAuthProfile ? OAuthProfile.email : tmpUser.emails[0].address;
+  const firstName = OAuthProfile ? OAuthProfile.name.first : user.profile.name.first;
+  const emailAddress = OAuthProfile ? OAuthProfile.email : user.emails[0].address;
 
   return sendEmail({
     to: emailAddress,

--- a/imports/api/Users/server/send-welcome-email.js
+++ b/imports/api/Users/server/send-welcome-email.js
@@ -2,12 +2,13 @@ import { Meteor } from 'meteor/meteor';
 import sendEmail from '../../../modules/server/send-email';
 import getOAuthProfile from '../../../modules/get-oauth-profile';
 
-export default (options, user) => {
-  const OAuthProfile = getOAuthProfile(options, user);
+export default (user) => {
+  const tmpUser = !user ? Meteor.user() : user;
+  const OAuthProfile = getOAuthProfile(tmpUser.profile, tmpUser);
 
   const applicationName = 'Application Name';
-  const firstName = OAuthProfile ? OAuthProfile.name.first : options.profile.name.first;
-  const emailAddress = OAuthProfile ? OAuthProfile.email : options.email;
+  const firstName = OAuthProfile ? OAuthProfile.name.first : tmpUser.profile.name.first;
+  const emailAddress = OAuthProfile ? OAuthProfile.email : tmpUser.emails[0].address;
 
   return sendEmail({
     to: emailAddress,

--- a/imports/startup/server/accounts/oauth.js
+++ b/imports/startup/server/accounts/oauth.js
@@ -4,14 +4,12 @@ import { ServiceConfiguration } from 'meteor/service-configuration';
 if (Meteor.settings.private && Meteor.settings.private.OAuth) {
   const OAuthSettings = Meteor.settings.private.OAuth;
 
-  if (OAuthSettings) {
-    Object.keys(OAuthSettings).forEach((service) => {
-      ServiceConfiguration.configurations.upsert(
-        { service },
-        { $set: OAuthSettings[service] },
-      );
-    });
-  }
+  Object.keys(OAuthSettings).forEach((service) => {
+    ServiceConfiguration.configurations.upsert(
+      { service },
+      { $set: OAuthSettings[service] },
+    );
+  });
 } else {
-  console.warn('Warning! Oauth settings are not configured. OAuth logins will not function.');
+  console.warn('Warning! OAuth settings are not configured. OAuth logins will not function.');
 }

--- a/imports/startup/server/accounts/oauth.js
+++ b/imports/startup/server/accounts/oauth.js
@@ -1,13 +1,17 @@
 import { Meteor } from 'meteor/meteor';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 
-const OAuthSettings = Meteor.settings.private.OAuth;
+if (Meteor.settings.private && Meteor.settings.private.OAuth) {
+  const OAuthSettings = Meteor.settings.private.OAuth;
 
-if (OAuthSettings) {
-  Object.keys(OAuthSettings).forEach((service) => {
-    ServiceConfiguration.configurations.upsert(
-      { service },
-      { $set: OAuthSettings[service] },
-    );
-  });
+  if (OAuthSettings) {
+    Object.keys(OAuthSettings).forEach((service) => {
+      ServiceConfiguration.configurations.upsert(
+        { service },
+        { $set: OAuthSettings[service] },
+      );
+    });
+  }
+} else {
+  console.warn('Warning! Oauth settings are not configured. OAuth logins will not function.');
 }

--- a/imports/startup/server/accounts/on-create-user.js
+++ b/imports/startup/server/accounts/on-create-user.js
@@ -1,10 +1,12 @@
 import { Accounts } from 'meteor/accounts-base';
+import getOAuthProfile from '../../../modules/get-oauth-profile';
 import sendWelcomeEmail from '../../../api/Users/server/send-welcome-email';
 
 Accounts.onCreateUser((options, user) => {
   const userToCreate = user;
   if (options.profile) userToCreate.profile = options.profile;
-  sendWelcomeEmail(options, user);
+  const OAuthProfile = getOAuthProfile(options.profile, user);
+  if (OAuthProfile) sendWelcomeEmail(user);
   userToCreate.roles = ['user']; // Set default roles for new sign ups.
   return userToCreate;
 });

--- a/imports/startup/server/email.js
+++ b/imports/startup/server/email.js
@@ -1,3 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
-if (Meteor.isDevelopment) process.env.MAIL_URL = Meteor.settings.private.MAIL_URL;
+if (Meteor.settings.private && Meteor.settings.private.MAIL_URL) {
+  if (Meteor.isDevelopment) process.env.MAIL_URL = Meteor.settings.private.MAIL_URL;
+} else {
+  console.warn('Warning! You have not configured mail settings. Emails will not be sent.');
+}

--- a/imports/startup/server/email.js
+++ b/imports/startup/server/email.js
@@ -3,5 +3,5 @@ import { Meteor } from 'meteor/meteor';
 if (Meteor.settings.private && Meteor.settings.private.MAIL_URL) {
   if (Meteor.isDevelopment) process.env.MAIL_URL = Meteor.settings.private.MAIL_URL;
 } else {
-  console.warn('Warning! You have not configured mail settings. Emails will not be sent.');
+  console.warn('Warning! You have not configured e-mail settings. E-mails will not be sent.');
 }

--- a/imports/ui/pages/VerifyEmail/VerifyEmail.js
+++ b/imports/ui/pages/VerifyEmail/VerifyEmail.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Meteor } from 'meteor/meteor';
 import { Alert } from 'react-bootstrap';
 import { Accounts } from 'meteor/accounts-base';
 import { Bert } from 'meteor/themeteorchef:bert';
@@ -19,7 +20,13 @@ class VerifyEmail extends React.Component {
       } else {
         setTimeout(() => {
           Bert.alert('All set, thanks!', 'success');
-          history.push('/documents');
+          Meteor.call('users.sendWelcomeEmail', (errorMethod) => {
+            if (errorMethod) {
+              Bert.alert(errorMethod.reason, 'danger');
+            } else {
+              history.push('/documents');
+            }
+          });
         }, 1500);
       }
     });


### PR DESCRIPTION
Addresses #134 & #132. 132 was straight forward adding both a check to oath & email url. 

Preventing welcome email was slightly more tricky. Given OAuth emails are verified by default, its still appropriate to send out during on create user call. 

For non OAuth users, email should be sent once verification is successful (i.e. Client side). In addition, during verification call we do not have access to the user object and it must be called server side (using Meteor.user). 