### PR TITLE
Setting babel-plugin-lodash as production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@babel/runtime": "^7.0.0-beta.44",
     "@cleverbeagle/seeder": "^1.3.1",
     "b64-to-blob": "^1.2.19",
+    "babel-plugin-lodash": "^3.3.2",
     "babel-runtime": "^6.26.0",
     "bcrypt": "^2.0.1",
     "commonmark": "^0.28.1",
@@ -45,7 +46,6 @@
   },
   "devDependencies": {
     "babel-jest": "^22.4.3",
-    "babel-plugin-lodash": "^3.3.2",
     "enzyme": "^3.3.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",


### PR DESCRIPTION
I've observed the problem, that I could not build a Pup-based Meteor application for Docker using https://hub.docker.com/r/tozd/meteor/ 

The [Dockerfile](https://github.com/tozd/docker-meteor/blob/master/ubuntu-xenial.dockerfile) installs the dependencies for building using `npm install --production`, and *babel-plugin-lodash* is needed for building.

Therefore, I propose this change.