### PR TITLE
Use sendVerificationEmail mutation instead of nonexistent Meteor method

### DIFF
--- a/ui/pages/Signup/index.js
+++ b/ui/pages/Signup/index.js
@@ -2,18 +2,19 @@ import React from 'react';
 import { Row, Col, FormGroup, ControlLabel, Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Meteor } from 'meteor/meteor';
+import { graphql } from 'react-apollo';
 import { Accounts } from 'meteor/accounts-base';
 import { Bert } from 'meteor/themeteorchef:bert';
 import Validation from '../../components/Validation';
 import OAuthLoginButtons from '../../components/OAuthLoginButtons';
 import InputHint from '../../components/InputHint';
 import AccountPageFooter from '../../components/AccountPageFooter';
+import { sendVerificationEmail as sendVerificationEmailMutation } from '../../mutations/Users.gql';
 import StyledSignup from './styles';
 
 class Signup extends React.Component {
   handleSubmit = (form) => {
-    const { history } = this.props;
+    const { history, sendVerificationEmail } = this.props;
 
     Accounts.createUser(
       {
@@ -30,7 +31,7 @@ class Signup extends React.Component {
         if (error) {
           Bert.alert(error.reason, 'danger');
         } else {
-          Meteor.call('users.sendVerificationEmail');
+          sendVerificationEmail();
           Bert.alert('Welcome!', 'success');
           history.push('/documents');
         }
@@ -155,6 +156,9 @@ class Signup extends React.Component {
 
 Signup.propTypes = {
   history: PropTypes.object.isRequired,
+  sendVerificationEmail: PropTypes.func.isRequired,
 };
 
-export default Signup;
+export default graphql(sendVerificationEmailMutation, {
+  name: 'sendVerificationEmail',
+})(Signup);


### PR DESCRIPTION
After a Signup of a new user you can see this error in the console:
**Error invoking Method 'users.sendVerificationEmail'**
errorClass {isClientSafe: true, error: 404, reason: **"Method 'users.sendVerificationEmail' not found"**