### PR TITLE
Make the pup schema executable so that pupql doesn't need to do it

### DIFF
--- a/startup/server/api.js
+++ b/startup/server/api.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { makeExecutableSchema } from 'graphql-tools';
 
 import UserTypes from '../../api/Users/types';
 import UserQueries from '../../api/Users/queries';
@@ -83,4 +84,4 @@ const schema = {
   },
 };
 
-export default schema;
+export default makeExecutableSchema(schema);


### PR DESCRIPTION
This PR needs to be accepted in conjunction with my other matching PR on pupql. Basically the approach I'm taking is to feed pupql a schema that is already executable so that it doesn't have to do it. This has the benefit of allowing pupql to accept a merged/stitched schema.