### PR TITLE
checkBlackListed behaviour fixed to support an array of patterns fixes #332

### DIFF
--- a/modules/server/blackListedPatterns.js
+++ b/modules/server/blackListedPatterns.js
@@ -1,0 +1,1 @@
+export default ['/documents(/:id)','/some/route'];

--- a/modules/server/checkIfBlacklisted.js
+++ b/modules/server/checkIfBlacklisted.js
@@ -1,10 +1,12 @@
 import UrlPattern from 'url-pattern';
+import blackListedPatterns from './blackListedPatterns';
 
 export default (url) => {
-  let isBlacklisted = false;
-  ['/documents(/:id)'].forEach((blacklistedPattern) => {
-    const pattern = new UrlPattern(blacklistedPattern);
-    isBlacklisted = !!pattern.match(url);
-  });
-  return isBlacklisted;
+  if (blackListedPatterns && blackListedPatterns.length) {
+    return blackListedPatterns.some((blacklistedPattern) => {
+      const pattern = new UrlPattern(blacklistedPattern);
+      return !!pattern.match(url) === true;
+    });
+  }
+  return false;
 };


### PR DESCRIPTION
patterns defined in separate file for better readability.
It could be done in Meteor.settings but I avoided this way in order to have one less meteor dependency